### PR TITLE
Externalise the basic logging configuration.

### DIFF
--- a/logging_config.ini
+++ b/logging_config.ini
@@ -1,0 +1,21 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=stdout
+
+[formatters]
+keys=simpleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=stdout
+
+[handler_stdout]
+class=StreamHandler
+formatter=simpleFormatter
+args=(sys.stdout,)
+
+[formatter_simpleFormatter]
+format=%(asctime)s: %(levelname)s: %(message)s
+datefmt=%Y%m%d %H:%M:%S


### PR DESCRIPTION
Mostly capture the existing logging date format in an `.ini` file, and switch all logging to Python's `logging` API.

This doesn't directly improve things, but makes local customisation of log output simpler.
